### PR TITLE
Fix maven structure of project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Eclipse/IntelliJ
+.classpath
+.project
+.settings/
+.idea/
+*.iml
+*.iws
+
+# Maven
+/target/

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
 	<url>https://github.com/fiji/jython-autocompletion</url>
 	<inceptionYear>2020</inceptionYear>
 	<organization>
-		<name>SciJava</name>
-		<url>https://scijava.org/</url>
+		<name>Fiji</name>
+		<url>https://fiji.sc</url>
 	</organization>
 	<licenses>
 		<license>

--- a/src/main/java/sc/fiji/jython/autocompletion/AutoCompletionUtil.java
+++ b/src/main/java/sc/fiji/jython/autocompletion/AutoCompletionUtil.java
@@ -1,4 +1,4 @@
-package org.fiji.jython.autocompletion;
+package sc.fiji.jython.autocompletion;
 
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
@acardona, this does the following:
1. Move contents to mandatory src/main/java directory. AFAICT, this is the only change needed to validate the project
2. Corrects org.fiji > sc.fiji prefix (which I assume is warranted?)
3. Corrects some pom fields according to 2.
4. Adds a .gitignore for IDE contributors

If 2-4 are a distraction, adopting 1 should suffice.
