### PR TITLE
Disable DocLint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,9 @@
 
 		<script-editor.version>0.5.12</script-editor.version>
 		<antlr-runtime.version>3.5.2</antlr-runtime.version>
+		
+		<!-- Temporarily disable DocLint -->
+		<doclint>none</doclint>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
This should allow CI builds: Currently, Javadoc generation seems to be failing due to
bad Javadoc annotations. Disabling DocLint should allow the build to progress. We
should however fix those issues for proper documentation