### PR TITLE
rename supported language to Python (Jython)

### DIFF
--- a/src/main/java/org/scijava/plugins/scripteditor/jython/JythonLanguageSupportPlugin.java
+++ b/src/main/java/org/scijava/plugins/scripteditor/jython/JythonLanguageSupportPlugin.java
@@ -59,7 +59,7 @@ public class JythonLanguageSupportPlugin extends  AbstractLanguageSupport implem
 
 	@Override
 	public String getLanguageName() {
-		return "python";
+		return "Python (Jython)";
 	}
 
 	@Override


### PR DESCRIPTION
This change will prevent confusion with the new Python (PyImageJ)
language. 

This change is required for autocompletion to work with the
renamed language in scripting-jython
https://github.com/scijava/scripting-jython/commit/07dc8b0a5fe840c0f70669be564cfc1f926c1f12